### PR TITLE
Make the -flto compile and link option work

### DIFF
--- a/dmcp/sys/pgm_syscalls.c
+++ b/dmcp/sys/pgm_syscalls.c
@@ -61,6 +61,7 @@ void Program_Entry();
 #define PROGRAM_KEYMAP_ID 0xffffffff
 #endif
 
+__attribute__((used, externally_visible, section(".rodata.prog_info")))
 prog_info_t const prog_info = {
 	PROG_INFO_MAGIC,       // uint32_t pgm_magic;
 	0,                     // uint32_t pgm_size;


### PR DESCRIPTION
This is to reduce the size of C47.pgm for the DM42 hardware